### PR TITLE
[FEAT]: 통계 대시보드 페이지 구현

### DIFF
--- a/pickme/src/main/resources/static/css/statistics/statisticsDashboard.css
+++ b/pickme/src/main/resources/static/css/statistics/statisticsDashboard.css
@@ -1,0 +1,134 @@
+body {
+    font-family: "IBM Plex Sans KR", sans-serif;
+    background-color: #f0f0f0;
+    margin: 0;
+    padding: 0;
+}
+.dashboard-title {
+    text-align: center;
+    color: #333;
+    padding-bottom: 10px;
+    border-bottom: 1px solid #ccc;
+    margin-bottom: 20px;
+    margin-left: 10%;
+    margin-right: 10%;
+}
+.dashboard {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 20px;
+    max-width: 1200px;
+    margin: 0 auto;
+}
+.card {
+    background-color: white;
+    border-radius: 10px;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    overflow: hidden;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    text-decoration: none;
+    color: inherit;
+}
+.card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
+}
+.card-image-container {
+    position: relative;
+    overflow: hidden;
+}
+.card-image {
+    width: 100%;
+    height: 200px;
+    object-fit: cover;
+    transition: transform 0.3s ease;
+}
+.card-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(76, 175, 80, 0.9);
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-items: center;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    padding: 20px;
+    color: white;
+}
+.card-image-container:hover .card-overlay {
+    opacity: 1;
+}
+.card-image-container:hover .card-image {
+    transform: scale(1.1);
+}
+.card-content {
+    padding: 15px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+.card-title {
+    font-size: 18px;
+    font-weight: bold;
+    color: #333;
+    margin: 0;
+}
+.tags {
+    display: flex;
+    gap: 5px;
+}
+.tag {
+    background-color: #e0e0e0;
+    padding: 3px 8px;
+    border-radius: 15px;
+    font-size: 12px;
+    color: #666;
+}
+.card-overlay-content {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    width: 100%;
+}
+.card-overlay-content ul {
+    list-style-type: none;
+    padding-left: 0;
+    margin: 0;
+}
+.card-overlay-content li {
+    position: relative;
+    padding-left: 20px;
+    margin-bottom: 10px;
+    color: white;
+    font-size: 14px;
+}
+.card-overlay-content li::before {
+    content: "•";
+    position: absolute;
+    left: 0;
+    color: white;
+}
+.overlay-icon-container {
+    width: 40px;
+    height: 40px;
+    background-color: white;
+    border-radius: 50%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-top: 15px;
+    flex-shrink: 0;
+}
+.overlay-icon {
+    color: #4CAF50;
+    font-size: 20px;
+}
+
+.card-image-container:hover .card-overlay {
+    opacity: 1;
+}

--- a/pickme/src/main/resources/templates/statistics/statisticsDashboard.html
+++ b/pickme/src/main/resources/templates/statistics/statisticsDashboard.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>통계 메인</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+KR:wght@100;200;300;400;500;600;700&display=swap" rel="stylesheet">
+     <link rel="stylesheet" th:href="@{/css/statistics/statisticsDashboard.css}">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js"></script>
+
+</head>
+<body>
+<h1 class="dashboard-title">주요통계 대시보드</h1>
+<div class="dashboard">
+    <a href="/경매통계" class="card">
+        <div class="card-image-container">
+            <img src="planning.jpg" alt="경매 관련 통계" class="card-image">
+            <div class="card-overlay">
+                <div class="card-overlay-content">
+                    <ul>
+                        <li>경매 참가자 수 추이</li>
+                        <li>물품별 경쟁률 분석</li>
+                        <li>낙찰률 변동 추이</li>
+                        <li>경매 성사율 통계</li>
+                    </ul>
+                </div>
+                <div class="overlay-icon-container">
+                    <i class="fas fa-arrow-right overlay-icon"></i>
+                </div>
+            </div>
+        </div>
+        <div class="card-content">
+            <h2 class="card-title">경매 관련 통계</h2>
+            <div class="tags">
+                <span class="tag">#경매</span>
+                <span class="tag">#경쟁률</span>
+                <span class="tag">#낙찰률</span>
+            </div>
+        </div>
+    </a>
+    <a href="/물품통계" class="card">
+        <div class="card-image-container">
+            <img src="planning.jpg" alt="물품 관련 통계" class="card-image">
+            <div class="card-overlay">
+                <div class="card-overlay-content">
+                    <ul>
+                        <li>물품 카테고리별 경매 비율</li>
+                        <li>자주 적발되는 물품 유형</li>
+                        <li>시작가 대비 낙찰가 평균</li>
+                        <li>미낙찰 물품 비율</li>
+                    </ul>
+                </div>
+                <div class="overlay-icon-container">
+                    <i class="fas fa-arrow-right overlay-icon"></i>
+                </div>
+            </div>
+        </div>
+        <div class="card-content">
+            <h2 class="card-title">물품 관련 통계</h2>
+            <div class="tags">
+                <span class="tag">#카테고리</span>
+                <span class="tag">#낙찰가</span>
+                <span class="tag">#물품유형</span>
+            </div>
+        </div>
+    </a>
+    <a href="/재정통계" class="card">
+        <div class="card-image-container">
+            <img src="planning.jpg" alt="재정 관련 통계" class="card-image">
+            <div class="card-overlay">
+                <div class="card-overlay-content">
+                    <ul>
+                        <li>총 경매 수익</li>
+                        <li>월별/연도별 수익 추이</li>
+                        <li>카테고리별 수익 비율</li>
+                        <li>평균 낙찰가 추이</li>
+                    </ul>
+                </div>
+                <div class="overlay-icon-container">
+                    <i class="fas fa-arrow-right overlay-icon"></i>
+                </div>
+            </div>
+        </div>
+        <div class="card-content">
+            <h2 class="card-title">재정 관련 통계</h2>
+            <div class="tags">
+                <span class="tag">#경매수익</span>
+                <span class="tag">#수익추이</span>
+                <span class="tag">#낙찰가추이</span>
+            </div>
+        </div>
+    </a>
+    <a href="/지역통계" class="card">
+        <div class="card-image-container">
+            <img src="planning.jpg" alt="지역별 통계" class="card-image">
+            <div class="card-overlay">
+                <div class="card-overlay-content">
+                    <ul>
+                        <li>적발 지역별 물품 분포</li>
+                        <li>지역별 낙찰자 분포</li>
+                        <li>지역별 평균 낙찰가 비교</li>
+                    </ul>
+                </div>
+                <div class="overlay-icon-container">
+                    <i class="fas fa-arrow-right overlay-icon"></i>
+                </div>
+            </div>
+        </div>
+        <div class="card-content">
+            <h2 class="card-title">지역별 통계</h2>
+            <div class="tags">
+                <span class="tag">#물품분포</span>
+                <span class="tag">#낙찰자분포</span>
+            </div>
+        </div>
+    </a>
+    <a href="/시간통계" class="card">
+        <div class="card-image-container">
+            <img src="planning.jpg" alt="시간 관련 통계" class="card-image">
+            <div class="card-overlay">
+                <div class="card-overlay-content">
+                    <ul>
+                        <li>월별 경매 물품 추이</li>
+                        <li>요일/시간대별 입찰 활성도</li>
+                        <li>경매 진행 시간대별 낙찰률</li>
+                        <li>평균 배송 소요 시간</li>
+                    </ul>
+                </div>
+                <div class="overlay-icon-container">
+                    <i class="fas fa-arrow-right overlay-icon"></i>
+                </div>
+            </div>
+        </div>
+        <div class="card-content">
+            <h2 class="card-title">시간 관련 통계</h2>
+            <div class="tags">
+                <span class="tag">#입찰활성도</span>
+                <span class="tag">#시간대별 낙찰률</span>
+            </div>
+        </div>
+    </a>
+    <a href="/법규통계" class="card">
+        <div class="card-image-container">
+            <img src="planning.jpg" alt="법규 관련 통계" class="card-image">
+            <div class="card-overlay">
+                <div class="card-overlay-content">
+                    <ul>
+                        <li>법규별 적발 물품 비율</li>
+                        <li>위반 유형별 평균 낙찰가</li>
+                        <li>법규 위반 변화 추이</li>
+                    </ul>
+                </div>
+                <div class="overlay-icon-container">
+                    <i class="fas fa-arrow-right overlay-icon"></i>
+                </div>
+            </div>
+        </div>
+        <div class="card-content">
+            <h2 class="card-title">법규 관련 통계</h2>
+            <div class="tags">
+                <span class="tag">#위반유형</span>
+                <span class="tag">#법규변화</span>
+            </div>
+        </div>
+    </a>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## 🍀이슈 번호
- closes #72 

## ✅ 구현 내용
- [x] 통계 대시보드 페이지 구현


## 🐸고민사항 & 기타
- 통계 단어가 statistics라 뒤에 어떤 내용이 붙어도 파일명이 너무 길어지는 느낌
- customs에서만 작업하다보니 user로 작업할 때 어떻게 접속하는지 몰라 vscode로 외관만 구현해 둔 상태(header, footer X)

<img width="1273" alt="image" src="https://github.com/user-attachments/assets/6111d252-7f4f-4153-9cb2-fc11fc2af7e0">
<img width="1276" alt="image" src="https://github.com/user-attachments/assets/9a956d84-be56-4bee-8b1e-04be354dd675">
