### PR TITLE
[FEAT]: 유저 메인 공매품 리스트 나열 구현

### DIFF
--- a/pickme/src/main/java/project/pickme/user/controller/MainpageController.java
+++ b/pickme/src/main/java/project/pickme/user/controller/MainpageController.java
@@ -1,0 +1,27 @@
+package project.pickme.user.controller;
+
+import java.util.List;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import lombok.RequiredArgsConstructor;
+import project.pickme.item.FindItemService;
+import project.pickme.item.dto.FindItemDto;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/")
+public class MainpageController {
+
+	private final FindItemService itemService;
+
+	@GetMapping
+	public String showMain(Model model) {
+		List<FindItemDto.GetAll> items = itemService.findAll();
+		model.addAttribute("items", items);
+		return "index";
+	}
+}

--- a/pickme/src/main/resources/static/css/userMain.css
+++ b/pickme/src/main/resources/static/css/userMain.css
@@ -191,22 +191,31 @@ body {
     height: auto;
     min-height: 400px;
     background-color: white;
-    border-radius: 10px;
+    border-bottom-right-radius: 30px;
     overflow: hidden;
-    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+    box-shadow: 0 0 30px rgba(0,0,0,0.2);
     position: relative;
+    transition: box-shadow 0.3s ease-in-out;
 }
-
 
 .product-card .status {
     position: absolute;
     top: 10px;
     left: 10px;
-    background-color: red;
-    color: white;
     padding: 5px 10px;
     border-radius: 5px;
     font-size: 12px;
+    font-weight: bold;
+}
+
+.status-open {
+    background-color: #FF0000;
+    color: #FFF;
+}
+
+.status-closed {
+    background-color: black;
+    color: #FFF;
 }
 
 .product-card img {
@@ -217,7 +226,7 @@ body {
 
 .product-info {
     padding: 15px;
-    flex-grow: 1; /* 남은 공간을 채우도록 하는 설정(아래 4개) */
+    flex-grow: 1;
     display: flex;
     flex-direction: column;
     justify-content: space-between;
@@ -225,19 +234,19 @@ body {
 
 .product-info h3 {
     margin: 0 0 10px 0;
-    font-size: 14px;
+    font-size: 16px;
     font-weight: 600;
     color: #333;
     overflow: hidden;
     text-overflow: ellipsis;
     display: -webkit-box;
-    -webkit-line-clamp: 2; /* 최대 2줄 넘어가면 ... 으로 표현 */
+    -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
 }
 
 .product-info p {
     margin: 5px 0;
-    font-size: 12px;
+    font-size: 14px;
     color: #666;
     font-weight: 400;
 }

--- a/pickme/src/main/resources/static/css/userMain.css
+++ b/pickme/src/main/resources/static/css/userMain.css
@@ -158,8 +158,10 @@ body {
 }
 
 .navigation button {
+    min-height: 130px;
     font-family: "IBM Plex Sans KR", sans-serif;
-    font-weight: 500;
+    font-weight: 700;
+    font-size: 1rem;
     flex: 1;
     padding: 15px;
     border: none;
@@ -169,13 +171,13 @@ body {
     flex-direction: column;
     align-items: center;
     border-radius: 5px;
-    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+    box-shadow: 0 5px 10px rgba(0,0,0,0.1);
 }
 
 .navigation button img {
-    width: clamp(48px, 3vw, 56px);
-    height: clamp(48px, 3vw, 56px);
-    margin-bottom: 5px;
+    width: clamp(56px, 3vw, 72px);
+    height: clamp(56px, 3vw, 72px);
+    margin-bottom: 15px;
 }
 
 /* 제품 */
@@ -193,7 +195,7 @@ body {
     background-color: white;
     border-bottom-right-radius: 30px;
     overflow: hidden;
-    box-shadow: 0 0 30px rgba(0,0,0,0.2);
+    box-shadow: 0 0 15px rgba(0,0,0,0.2);
     position: relative;
     transition: box-shadow 0.3s ease-in-out;
 }
@@ -235,7 +237,7 @@ body {
 .product-info h3 {
     margin: 0 0 10px 0;
     font-size: 16px;
-    font-weight: 600;
+    font-weight: 700;
     color: #333;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -248,22 +250,22 @@ body {
     margin: 5px 0;
     font-size: 14px;
     color: #666;
-    font-weight: 400;
+    font-weight: 700;
 }
 
 .auction-date {
-    font-weight: 600;
+    font-weight: 700;
     color: #4CAF50;
 }
 
 .auction-end_date {
-    font-weight: 600;
+    font-weight: 700;
     color: #FF0000;
 }
 
 .product-info .price {
     color: #4CAF50;
-    font-weight: 600;
+    font-weight: 700;
 }
 
 /* 페이지네이션 */
@@ -280,22 +282,25 @@ body {
     border: none;
     font-size: 20px;
     cursor: pointer;
+    color: #2EC44F;
 }
 
 .page-dots {
     display: flex;
-    gap: 5px;
+    gap: 10px;
+    margin: 0 20px;
 }
 
 .dot {
     width: 10px;
     height: 10px;
-    background-color: #ccc;
+    background-color: #FFF;
+    border: 2px solid #000;
     border-radius: 50%;
 }
 
 .dot.active {
-    background-color: #4CAF50;
+    background-color: #2EC44F;
 }
 
 /* 반응형 디자인

--- a/pickme/src/main/resources/templates/index.html
+++ b/pickme/src/main/resources/templates/index.html
@@ -7,8 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+KR:wght@100;200;300;400;500;600;700&display=swap" rel="stylesheet">
-
-    <link rel="stylesheet" th:href="@{/css/common/index.css}">
+    <link rel="stylesheet" th:href="@{/css/userMain.css}">
     <link rel="stylesheet" th:href="@{/css/common/header.css}">
     <link rel="stylesheet" th:href="@{/css/common/footer.css}">
 </head>
@@ -20,7 +19,6 @@
                 <section class="campaign">
                     <img th:src="@{/images/imsi.png}" alt="캠페인" src="">
                 </section>
-
             </div>
             <div class="top-buttons">
                 <button class="custom-admin">
@@ -36,85 +34,33 @@
 
         <div class="navigation">
             <button><img th:src="@{/images/annoucement.png}" alt="배송" src="">배송현황</button>
-            <button><img th:src="@{/images/search-engine.png}" alt="공매물품조회" src="">공매물품조회</button>
-            <button><img th:src="@{/images/auction.png}" alt="입찰목록" src="">입찰목록</button>
+            <button th:onclick="|location.href='@{/user/item/list}'|"><img th:src="@{/images/search-engine.png}" alt="공매물품조회" src="">공매물품조회</button>
+            <button th:if="${userId != null}"
+                    th:onclick="|location.href='@{/user/item/' + ${userId}}'|">
+                <img th:src="@{/images/auction.png}" alt="입찰목록" src="">입찰목록
+            </button>
+            <button th:if="${userId == null}"
+                    th:onclick="|location.href='@{/user/loginForm}'|">
+                <img th:src="@{/images/auction.png}" alt="입찰목록" src="">입찰목록
+            </button>
             <button><img th:src="@{/images/point.png}" alt="포인트등록" src="">포인트등록</button>
             <button><img th:src="@{/images/myPage.png}" alt="마이페이지" src="">마이페이지</button>
             <button><img th:src="@{/images/data-analysis.png}" alt="통계" src="">통계</button>
         </div>
 
         <section class="products-grid">
-            <div class="product-card">
-                <span class="status">진행중</span>
-                <img th:src="@{/images/planning.jpg}" alt="제품 1" src="">
+            <div th:each="item : ${items}" class="product-card">
+                <span class="status" th:classappend="${item.status == 'OPEN' ? 'status-open' : 'status-closed'}"
+                      th:text="${item.status == 'OPEN' ? '진행중' : '마감'}">진행중</span>
+                <img th:src="@{${item.imgUrl}}" alt="제품" src="">
                 <div class="product-info">
-                    <h3>Jumper Laptop16 InchDDR4 16G5SD 512Value LaptopSlimFHD</h3>
-                    <p>공매예상가격 <span class="price">36000원</span></p>
+                    <h3 th:text="${item.name}">제품 이름</h3>
+                    <p>공매예상가격 <span class="price" th:text="${item.price}">가격</span></p>
                     <p>
                         <span class="auction-label">공매시작시간</span>
-                        <span class="auction-date">2024-09-05 10:00</span><br>
+                        <span class="auction-date" th:text="${item.startTime}">공매시작시간</span><br>
                         <span class="auction-label">공매마감시간</span>
-                        <span class="auction-end_date">2024-09-06 10:00</span>
-                    </p>
-                </div>
-            </div>
-
-            <div class="product-card">
-                <span class="status">진행중</span>
-                <img th:src="@{/images/planning.jpg}" alt="제품 1" src="">
-                <div class="product-info">
-                    <h3>Jumper Laptop16 InchDDR4 16G5SD 512Value LaptopSlimFHD</h3>
-                    <p>공매예상가격 <span class="price">36000원</span></p>
-                    <p>
-                        <span class="auction-label">공매시작시간</span>
-                        <span class="auction-date">2024-09-05 10:00</span><br>
-                        <span class="auction-label">공매마감시간</span>
-                        <span class="auction-end_date">2024-09-06 10:00</span>
-                    </p>
-                </div>
-            </div>
-
-            <div class="product-card">
-                <span class="status">진행중</span>
-                <img th:src="@{/images/planning.jpg}" alt="제품 1" src="">
-                <div class="product-info">
-                    <h3>Jumper Laptop16 InchDDR4 16G5SD 512Value LaptopSlimFHD</h3>
-                    <p>공매예상가격 <span class="price">36000원</span></p>
-                    <p>
-                        <span class="auction-label">공매시작시간</span>
-                        <span class="auction-date">2024-09-05 10:00</span><br>
-                        <span class="auction-label">공매마감시간</span>
-                        <span class="auction-end_date">2024-09-06 10:00</span>
-                    </p>
-                </div>
-            </div>
-
-            <div class="product-card">
-                <span class="status">진행중</span>
-                <img th:src="@{/images/planning.jpg}" alt="제품 1" src="">
-                <div class="product-info">
-                    <h3>Jumper Laptop16 InchDDR4 16G5SD 512Value LaptopSlimFHD</h3>
-                    <p>공매예상가격 <span class="price">36000원</span></p>
-                    <p>
-                        <span class="auction-label">공매시작시간</span>
-                        <span class="auction-date">2024-09-05 10:00</span><br>
-                        <span class="auction-label">공매마감시간</span>
-                        <span class="auction-end_date">2024-09-06 10:00</span>
-                    </p>
-                </div>
-            </div>
-
-            <div class="product-card">
-                <span class="status">진행중</span>
-                <img th:src="@{/images/planning.jpg}" alt="제품 1" src="">
-                <div class="product-info">
-                    <h3>Jumper Laptop16 InchDDR4 16G5SD 512Value LaptopSlimFHD</h3>
-                    <p>공매예상가격 <span class="price">36000원</span></p>
-                    <p>
-                        <span class="auction-label">공매시작시간</span>
-                        <span class="auction-date">2024-09-05 10:00</span><br>
-                        <span class="auction-label">공매마감시간</span>
-                        <span class="auction-end_date">2024-09-06 10:00</span>
+                        <span class="auction-end_date" th:text="${item.endTime}">공매마감시간</span>
                     </p>
                 </div>
             </div>

--- a/pickme/src/main/resources/templates/index.html
+++ b/pickme/src/main/resources/templates/index.html
@@ -55,13 +55,9 @@
                 <img th:src="@{${item.imgUrl}}" alt="제품" src="">
                 <div class="product-info">
                     <h3 th:text="${item.name}">제품 이름</h3>
-                    <p>공매예상가격 <span class="price" th:text="${item.price}">가격</span></p>
-                    <p>
-                        <span class="auction-label">공매시작시간</span>
-                        <span class="auction-date" th:text="${item.startTime}">공매시작시간</span><br>
-                        <span class="auction-label">공매마감시간</span>
-                        <span class="auction-end_date" th:text="${item.endTime}">공매마감시간</span>
-                    </p>
+                    <p>공매예상가격 <span class="price" th:text="'￦  ' + ${item.price}">가격</span></p>
+                    <p class="auction-label">공매시작시간<span class="auction-date" th:text="${#temporals.format(item.startTime, 'yyyy-MM-dd HH:mm')}">공매시작시간</span></p>
+                    <p class="auction-label">공매마감시간<span class="auction-end_date" th:text="${#temporals.format(item.endTime, 'yyyy-MM-dd HH:mm')}">공매마감시간</span></p>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## 🍀이슈 번호
- closes #76 

## ✅ 구현 내용
- [x] 메인페이지 공매품 리스트 나열 구현
- [x] 공매품 리스트 카드 모양 요구사항 반영
- [x] 공매품 리스트 페이지네이션 디자인 요구사항 반영
- [x] 메뉴 네비게이터 요구사항 반영

## 🐸고민사항 & 기타
<img width="1234" alt="image" src="https://github.com/user-attachments/assets/3f64ea15-f80d-477e-b8a4-f9690bbbaf41">


