### PR TITLE
[FEAT]: 아이템 리스트 정렬조건 추가

### DIFF
--- a/pickme/src/main/resources/mapper/FindItemMapper.xml
+++ b/pickme/src/main/resources/mapper/FindItemMapper.xml
@@ -99,6 +99,13 @@
         left join Mine m
         on i.item_id = m.item_id
         and m.user_id = #{userId}
+
+        order by
+        case
+        when i.status in ('NOT_OPEN', 'OPEN') then 0
+        else 1
+        end,
+        i.end_time asc;
     </select>
 
     <select id="findItemByIdWithImage" parameterType="long" resultType="project.pickme.item.dto.OneBidItemDto">


### PR DESCRIPTION
## 🍀이슈 번호
- closes #114 

## ✅ 구현 내용
- [x] 아이템 리스트 정렬조건 추가(마감시간이 적게 남은순으로, 마감된 아이템은 맨 뒤로)

