### PR TITLE
[STYLE]: 메인 글씨 로고 축소 및 상품 가격단위 콤마 추가

### DIFF
--- a/pickme/src/main/resources/static/css/common/userMainHeader.css
+++ b/pickme/src/main/resources/static/css/common/userMainHeader.css
@@ -48,7 +48,7 @@ header {
 .header-logo {
     text-decoration: none;
     color: inherit;
-    font-size: calc(10px + 0.9vw);
+    font-size: calc(10px + 0.8vw);
     font-weight: bold;
     margin-right: 60px;
     margin-left: 20px;

--- a/pickme/src/main/resources/templates/index.html
+++ b/pickme/src/main/resources/templates/index.html
@@ -60,7 +60,7 @@
                 <img th:src="@{${item.imgUrl}}" alt="제품" src="">
                 <div class="product-info">
                     <h3 th:text="${item.name}">제품 이름</h3>
-                    <p>공매예상가격 <span class="price" th:text="'￦  ' + ${item.price}">가격</span></p>
+                    <p>공매예상가격 <span class="price" th:text="'￦  ' + ${#numbers.formatDecimal(item.price, 0, 'COMMA', 0, 'POINT')}">가격</span></p>
                     <p class="auction-label">공매시작시간<span class="auction-date" th:text="'  '+ ${#temporals.format(item.startTime, 'yyyy-MM-dd HH:mm')}">공매시작시간</span></p>
                     <p class="auction-label">공매마감시간<span class="auction-end_date" th:text="'  '+ ${#temporals.format(item.endTime, 'yyyy-MM-dd HH:mm')}">공매마감시간</span></p>
                 </div>


### PR DESCRIPTION
## 🍀이슈 번호
- closes #103 

## ✅ 구현 내용
- [x] 메인 헤더 로고 글씨 축소
- [x] 상품 가격단위 콤마 추가

## 🐸고민사항 & 기타
코드 : `<span class="currency">￦</span> <span th:text="${#numbers.formatDecimal(item.price, 0, 'COMMA', 0, 'POINT')}">`

<img width="892" alt="image" src="https://github.com/user-attachments/assets/ca6dc158-f446-414c-9088-cf4f6f1ea876">
