### PR TITLE
[FEAT]: 메인 페이지 접속 상태 구분 및 공매품 상위 20개 나열 구현

### DIFF
--- a/pickme/src/main/java/project/pickme/item/repository/FindItemMapper.java
+++ b/pickme/src/main/java/project/pickme/item/repository/FindItemMapper.java
@@ -14,6 +14,10 @@ import project.pickme.item.dto.OneBidItemDto;
 public interface FindItemMapper {
 	Optional<FindItemDto.GetOne> findById(@Param("id") Long id, @Param("userId") String currentUserId);
 
+	List<FindItemDto.GetAll> findAll();
+
+	List<FindItemDto.GetAll> findTop20();
+
 	Optional<Item> findItemById(Long itemId);
 
 	OneBidItemDto findItemByIdWithImage(Long itemId);

--- a/pickme/src/main/java/project/pickme/item/service/FindItemService.java
+++ b/pickme/src/main/java/project/pickme/item/service/FindItemService.java
@@ -27,6 +27,10 @@ public class FindItemService {
 		return itemMapper.findAll(userId, category);
 	}
 
+	public List<FindItemDto.GetAll> findTop20() {
+		return itemMapper.findTop20();
+	}
+
 	public OneBidItemDto showOneBidItem(User user, Long itemId) {
 		OneBidItemDto onBidItemDto = itemMapper.findItemByIdWithImage(itemId);
 		onBidItemDto.setUserId(user.getId());

--- a/pickme/src/main/java/project/pickme/user/controller/MainController.java
+++ b/pickme/src/main/java/project/pickme/user/controller/MainController.java
@@ -20,9 +20,9 @@ public class MainController {
 	private final FindItemService itemService;
 
 	@GetMapping("/user/main")
-	public String showMain(@CurrentUser User user, Model model) {
-		// List<FindItemDto.GetAll> items = itemService.findAll(user.getId());
-		// model.addAttribute("items", items);
+	public String showMain(Model model) {
+		List<FindItemDto.GetAll> items = itemService.findTop20();
+		model.addAttribute("items", items);
 		return "index";
 	}
 

--- a/pickme/src/main/resources/mapper/FindItemMapper.xml
+++ b/pickme/src/main/resources/mapper/FindItemMapper.xml
@@ -72,7 +72,7 @@
         c.id, c.name, c.tel, m.like_id, m.status
     </select>
 
-    <select id = "findAll" parameterType="map" resultType="project.pickme.item.dto.FindItemDto$GetAll">
+    <select id = "findAll" parameterType="string" resultType="project.pickme.item.dto.FindItemDto$GetAll">
         select
         i.item_id as id,
         i.name,
@@ -91,7 +91,6 @@
         from
         Item i
 
-        -- Join Image table
         join Image img
         on i.item_id = img.item_id
         and img.seq = 0
@@ -100,20 +99,29 @@
         left join Mine m
         on i.item_id = m.item_id
         and m.user_id = #{userId}
+    </select>
 
-        <if test="category != 'all'">
-            -- Join Category table
-            join Category c
-            on i.code = c.code
-            and c.name = #{category}
-        </if>
-
+    <select id = "findTop20" parameterType="string" resultType="project.pickme.item.dto.FindItemDto$GetAll">
+        select
+            i.item_id as id,
+            i.name,
+            i.price,
+            i.start_time as startTime,
+            i.end_time as endTime,
+            i.status,
+            img.url as imgUrl
+        from
+            Item i
+        join
+            Image img
+        on
+            i.item_id = img.item_id
+            and img.seq = 0
+        where
+            status != 'CLOSED'
         order by
-        case
-        when i.status in ('NOT_OPEN', 'OPEN') then 0
-        else 1
-        end,
-        i.end_time asc;
+            endTime asc
+        limit 20
     </select>
 
     <select id="findItemByIdWithImage" parameterType="long" resultType="project.pickme.item.dto.OneBidItemDto">

--- a/pickme/src/main/resources/templates/fragments/userMainHeader.html
+++ b/pickme/src/main/resources/templates/fragments/userMainHeader.html
@@ -13,8 +13,13 @@
     <div class="top-green-bar">
         <a th:href="@{/user/main}" class="header-logo">PICK-ME</a>
         <div class="header-buttons">
-            <a th:href="@{/user/loginForm}" class="header-login">로그인</a>
-            <button class="logout-btn" th:onclick="|location.href='@{/user/signUpForm}'|">회원가입</button>
+            <th:block sec:authorize="isAnonymous()">
+                <a th:href="@{/user/loginForm}" class="header-login">로그인</a>
+                <button class="signup-btn" th:onclick="|location.href='@{/user/signUpForm}'|">회원가입</button>
+            </th:block>
+            <th:block sec:authorize="isAuthenticated()">
+                <button class="logout-btn" th:onclick="|location.href='@{/user/loginForm}'|">로그아웃</button>
+            </th:block>
         </div>
     </div>
     <div class="header-content">


### PR DESCRIPTION
## 🍀이슈 번호
- closes #139 

## ✅ 구현 내용
- [x] 메인 페이지 로그인/로그아웃 상태에 따른 버튼 분리 구현
- [x] 메인 페이지 공매품 리스트 상위 20개만 나열 구현

## 🐸고민사항 & 기타
- 마감 기준 상위 20개 출력
- 이전 이슈 git 에러로 재등록