### PR TITLE
[FEAT]: 경매 관련 통계 페이지 구현

### DIFF
--- a/pickme/src/main/java/project/pickme/statistics/controller/RestStatisticsController.java
+++ b/pickme/src/main/java/project/pickme/statistics/controller/RestStatisticsController.java
@@ -16,7 +16,6 @@ import project.pickme.statistics.service.StatisticsService;
 public class RestStatisticsController {
 	private final StatisticsService statisticsService;
 
-
 	@GetMapping("/auctionStatistics")
 	public BaseResponse<Map<String, Object>> getStatisticsData() {
 		Map<String, Object> statisticsData = statisticsService.getAllStatistics();

--- a/pickme/src/main/java/project/pickme/statistics/controller/RestStatisticsController.java
+++ b/pickme/src/main/java/project/pickme/statistics/controller/RestStatisticsController.java
@@ -1,0 +1,25 @@
+package project.pickme.statistics.controller;
+
+import java.util.Map;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import project.pickme.common.response.BaseResponse;
+import project.pickme.statistics.service.StatisticsService;
+
+@RestController
+@RequestMapping("/api/statistics")
+@RequiredArgsConstructor
+public class RestStatisticsController {
+	private final StatisticsService statisticsService;
+
+
+	@GetMapping("/auctionStatistics")
+	public BaseResponse<Map<String, Object>> getStatisticsData() {
+		Map<String, Object> statisticsData = statisticsService.getAllStatistics();
+		return BaseResponse.ok(statisticsData);
+	}
+}

--- a/pickme/src/main/java/project/pickme/statistics/controller/StatisticsController.java
+++ b/pickme/src/main/java/project/pickme/statistics/controller/StatisticsController.java
@@ -5,7 +5,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import lombok.RequiredArgsConstructor;
-import project.pickme.statistics.service.StatisticsService;
 
 @Controller
 @RequestMapping("/user/statistics")

--- a/pickme/src/main/java/project/pickme/statistics/controller/StatisticsController.java
+++ b/pickme/src/main/java/project/pickme/statistics/controller/StatisticsController.java
@@ -1,0 +1,19 @@
+package project.pickme.statistics.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import lombok.RequiredArgsConstructor;
+import project.pickme.statistics.service.StatisticsService;
+
+@Controller
+@RequestMapping("/user/statistics")
+@RequiredArgsConstructor
+public class StatisticsController {
+
+	@GetMapping("/auctionStatistics")
+	public String showStatisticsPage() {
+		return "statistics/auctionStatistics";
+	}
+}

--- a/pickme/src/main/java/project/pickme/statistics/dto/CategoryCompetitionDto.java
+++ b/pickme/src/main/java/project/pickme/statistics/dto/CategoryCompetitionDto.java
@@ -1,0 +1,13 @@
+package project.pickme.statistics.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CategoryCompetitionDto {
+	private String categoryCode;
+	private int totalBids;
+	private int totalUsers;
+	private double competitionRate;
+}

--- a/pickme/src/main/java/project/pickme/statistics/dto/MonthlyBidStatisticsDto.java
+++ b/pickme/src/main/java/project/pickme/statistics/dto/MonthlyBidStatisticsDto.java
@@ -1,0 +1,13 @@
+package project.pickme.statistics.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MonthlyBidStatisticsDto {
+	private String bidMonth;
+	private int totalBids;
+	private int totalUsers;
+	private double competitionRate;
+}

--- a/pickme/src/main/java/project/pickme/statistics/repository/StatisticsMapper.java
+++ b/pickme/src/main/java/project/pickme/statistics/repository/StatisticsMapper.java
@@ -1,0 +1,26 @@
+package project.pickme.statistics.repository;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import project.pickme.statistics.dto.CategoryCompetitionDto;
+import project.pickme.statistics.dto.MonthlyBidStatisticsDto;
+
+@Mapper
+public interface StatisticsMapper {
+	// 총 경매건(전체)
+	int getTotalAuctions();
+
+	// 총 경매(월별)
+	List<MonthlyBidStatisticsDto> getMonthlyBids();
+
+	// 전체 경쟁률
+	double getTotalCompetitionRate();
+
+	// 월별 경쟁률
+	List<MonthlyBidStatisticsDto> getMonthlyCompetitionRate();
+
+	// 카테고리별 경쟁률
+	List<CategoryCompetitionDto> getCategoryCompetition();
+}

--- a/pickme/src/main/java/project/pickme/statistics/service/StatisticsService.java
+++ b/pickme/src/main/java/project/pickme/statistics/service/StatisticsService.java
@@ -1,0 +1,30 @@
+package project.pickme.statistics.service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import project.pickme.statistics.repository.StatisticsMapper;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StatisticsService {
+	private final StatisticsMapper statisticsMapper;
+
+	public Map<String, Object> getAllStatistics() {
+		Map<String, Object> data = new HashMap<>();
+
+		data.put("totalAuctions", statisticsMapper.getTotalAuctions());
+		data.put("monthlyBids", statisticsMapper.getMonthlyBids());
+		data.put("totalCompetitionRate", statisticsMapper.getTotalCompetitionRate());
+		data.put("monthlyCompetitionRate", statisticsMapper.getMonthlyCompetitionRate());
+		data.put("categoryCompetition", statisticsMapper.getCategoryCompetition());
+
+		return data;
+	}
+}

--- a/pickme/src/main/java/project/pickme/statistics/service/StatisticsService.java
+++ b/pickme/src/main/java/project/pickme/statistics/service/StatisticsService.java
@@ -1,7 +1,6 @@
 package project.pickme.statistics.service;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.springframework.stereotype.Service;

--- a/pickme/src/main/resources/mapper/StatisticsMapper.xml
+++ b/pickme/src/main/resources/mapper/StatisticsMapper.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="project.pickme.statistics.repository.StatisticsMapper">
+
+    <!-- 총 경매건(전체) -->
+    <select id="getTotalAuctions" resultType="int">
+        SELECT COUNT(DISTINCT item_id) FROM Bid
+    </select>
+
+    <!-- 총 경매(월별) -->
+    <select id="getMonthlyBids" resultType="project.pickme.statistics.dto.MonthlyBidStatisticsDto">
+        SELECT DATE_FORMAT(i.start_time, '%Y-%m') AS bid_month,
+        COUNT(b.bid_id) AS total_bids,
+        COUNT(DISTINCT b.user_id) AS total_users,
+        (COUNT(b.bid_id) / COUNT(DISTINCT b.user_id)) AS competition_rate
+        FROM Bid b
+        LEFT JOIN Item i ON b.item_id = i.item_id
+        GROUP BY DATE_FORMAT(i.start_time, '%Y-%m')
+        ORDER BY bid_month ASC
+    </select>
+
+    <!-- 전체 경쟁률 -->
+    <select id="getTotalCompetitionRate" resultType="double">
+        SELECT ROUND((SELECT COUNT(item_id) FROM Bid) /
+        (SELECT COUNT(DISTINCT user_id) FROM Bid WHERE item_id = 9), 2)
+        AS competition_rate FROM dual
+    </select>
+
+    <!-- 월별 경쟁률 -->
+    <select id="getMonthlyCompetitionRate" resultType="project.pickme.statistics.dto.MonthlyBidStatisticsDto">
+        SELECT DATE_FORMAT(b.bid_time, '%Y-%m') AS bid_month,
+        COUNT(b.bid_id) AS total_bids,
+        COUNT(DISTINCT b.user_id) AS total_users,
+        (COUNT(b.bid_id) / COUNT(DISTINCT b.user_id)) AS competition_rate
+        FROM Bid b
+        GROUP BY DATE_FORMAT(b.bid_time, '%Y-%m')
+        ORDER BY bid_month ASC
+    </select>
+
+    <!-- 카테고리별 경쟁률 -->
+    <select id="getCategoryCompetition" resultType="project.pickme.statistics.dto.CategoryCompetitionDto">
+        SELECT i.code AS category_code,
+        COUNT(b.bid_id) AS total_bids,
+        COUNT(DISTINCT b.user_id) AS total_users,
+        ROUND((COUNT(b.bid_id) / COUNT(DISTINCT b.user_id)), 2) AS competition_rate
+        FROM Item i
+        LEFT JOIN Bid b ON i.item_id = b.item_id
+        GROUP BY i.code
+        ORDER BY competition_rate DESC
+    </select>
+
+
+</mapper>

--- a/pickme/src/main/resources/static/css/statistics/auctionStatistics.css
+++ b/pickme/src/main/resources/static/css/statistics/auctionStatistics.css
@@ -12,46 +12,6 @@ body {
     background: white;
     padding: 20px;
 }
-/*
-.statistics-title {
-    text-align: center;
-    border-bottom: 1px solid #9DA0AE;
-    padding-bottom: 10px;
-    margin-bottom: 20px;
-}
-
-.section-title {
-    text-align
-}
-
-.dashboard-container {
-    width: 100%;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 20px;
-}
-.chart-row {
-    display: flex;
-    justify-content: space-between;
-    margin-bottom: 20px;
-}
-.chart-container {
-    background-color: #f8f8f8;
-    border-radius: 10px;
-    padding: 15px;
-    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
-}
-.chart-small {
-    width: 30%;
-}
-
-.chart-middle {
-    width: 66%;
-}
-.chart-large {
-    width: 100%;
-}
-*/
 
 .dashboard-container {
     width: 100%;
@@ -72,12 +32,14 @@ body {
     justify-content: space-between;
     margin-bottom: 40px;
 }
+
 .chart-container {
     background-color: #f8f8f8;
     border-radius: 10px;
     padding: 15px;
     box-shadow: 0 2px 5px rgba(0,0,0,0.1);
 }
+
 .chart-small {
     width: 30%;
 }

--- a/pickme/src/main/resources/static/css/statistics/auctionStatistics.css
+++ b/pickme/src/main/resources/static/css/statistics/auctionStatistics.css
@@ -1,0 +1,100 @@
+body {
+    font-family: "IBM Plex Sans KR", sans-serif;
+    line-height: 1.6;
+    margin: 0;
+    padding: 20px;
+    background-color: #fff;
+}
+
+.container {
+    max-width: 1200px;
+    margin: auto;
+    background: white;
+    padding: 20px;
+}
+/*
+.statistics-title {
+    text-align: center;
+    border-bottom: 1px solid #9DA0AE;
+    padding-bottom: 10px;
+    margin-bottom: 20px;
+}
+
+.section-title {
+    text-align
+}
+
+.dashboard-container {
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 20px;
+}
+.chart-row {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 20px;
+}
+.chart-container {
+    background-color: #f8f8f8;
+    border-radius: 10px;
+    padding: 15px;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+}
+.chart-small {
+    width: 30%;
+}
+
+.chart-middle {
+    width: 66%;
+}
+.chart-large {
+    width: 100%;
+}
+*/
+
+.dashboard-container {
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+.statistics-title {
+    text-align: center;
+    border-bottom: 1px solid #9DA0AE;
+    padding-bottom: 10px;
+    margin-bottom: 20px;
+}
+
+.chart-row {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 40px;
+}
+.chart-container {
+    background-color: #f8f8f8;
+    border-radius: 10px;
+    padding: 15px;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+}
+.chart-small {
+    width: 30%;
+}
+
+.chart-middle {
+    width: 66%;
+}
+
+.chart-large {
+    width: 100%;
+}
+
+.section-title {
+    text-align: center;
+    margin-bottom: 10px;
+}
+
+#totalAuctionsChart {
+    height: 400px;
+}

--- a/pickme/src/main/resources/static/js/statistics/auctionStatistics.js
+++ b/pickme/src/main/resources/static/js/statistics/auctionStatistics.js
@@ -1,4 +1,3 @@
-
 $(document).ready(function() {
     $.ajax({
         url: '/api/statistics/auctionStatistics',
@@ -13,6 +12,12 @@ $(document).ready(function() {
                 let monthlyBids = data.monthlyBids;
 
                 createTotalAuctionsChart(totalAuctions, totalCompetitionRate);
+                createMonthlyAuctionsChart(monthlyBids);
+                createCategoryCompetitionRate(categoryCompetition);
+
+                console.log('categoryCompetition:', totalAuctions);
+                console.log('categoryCompetition:', totalCompetitionRate);
+                console.log('monthlyBids:', monthlyBids);
             } else {
                 console.error('Failed to fetch data');
             }
@@ -28,7 +33,6 @@ function createTotalAuctionsChart(totalAuctions, totalCompetitionRate){
 
         chart: {
             type: 'column',
-//            styledMode: true
         },
 
         title: {
@@ -37,9 +41,7 @@ function createTotalAuctionsChart(totalAuctions, totalCompetitionRate){
         },
 
         subtitle: {
-            text: 'Source: ' +
-                '<a href="https://www.worlddata.info/average-bodyheight.php"' +
-                'target="_blank">WorldData</a>',
+            text: 'PICK-ME',
             align: 'left'
         },
 
@@ -71,18 +73,156 @@ function createTotalAuctionsChart(totalAuctions, totalCompetitionRate){
             name: '총 경매수',
             data: [totalAuctions, 0],
             yAxis: 0
-    //        tooltip: {
-    //            valueSuffix: ' 건'
-    //        }
         }, {
             name: '전체 경쟁률',
             data: [0, totalCompetitionRate],
             yAxis: 1
         }]
+    });
+}
 
+function createCategoryCompetitionRate(categoryCompetition) {
+    Highcharts.chart('categoryCompetitionChart', {
+        chart: {
+            type: 'column'
+        },
+        title: {
+            text: '카테고리별 경쟁률'
+        },
+        subtitle: {
+            text: 'PICK-ME'
+        },
+        xAxis: {
+            type: 'category',
+            labels: {
+                autoRotation: [-45, -90],
+                style: {
+                    fontSize: '13px',
+                    fontFamily: 'IBM Plex Sans KR'
+                }
+            }
+        },
+        yAxis: {
+            min: 0,
+            title: {
+                text: '경쟁률'
+            }
+        },
+        legend: {
+            enabled: false
+        },
+        tooltip: {
+            pointFormat: '경쟁률'
+        },
+        series: [{
+            name: '경쟁률',
+            colors: [
+                '#9b20d9', '#691af3', '#4551d5', '#1f88b7', '#00f194'
+            ],
+            colorByPoint: true,
+            groupPadding: 0,
+            data: [
+                ['의류', 7.33],
+                ['생활용품', 3.18],
+                ['디지털', 7.79],
+                ['가구', 4.23],
+                ['소모품', 5.23]
+            ],
+            dataLabels: {
+                enabled: true,
+                rotation: -90,
+                color: '#FFFFFF',
+                inside: true,
+                verticalAlign: 'top',
+                format: '{point.y:.1f}',
+                y: 10,
+                style: {
+                    fontSize: '13px',
+                    fontFamily: 'IBM Plex Sans KR'
+                }
+            }
+        }]
     });
 }
 
 function createMonthlyAuctionsChart(monthlyBids){
+    Highcharts.chart('monthlyAuctionsChart', {
+        chart: {
+            zooming: {
+                type: 'xy'
+            }
+        },
+        title: {
+            text: '월별 경매 수/경쟁률',
+            align: 'left'
+        },
+        credits: {
+            text: 'PICK-ME'
+        },
+        xAxis: [{
+            categories: [
+                '1월', '2월', '3월', '4월', '5월', '6월',
+                '7월', '8월', '9월', '10월', '11월', '12월'
+            ],
+            crosshair: true
+        }],
+        yAxis: [{
+            labels: {
+                format: '{value}건',
+                style: {
+                    color: Highcharts.getOptions().colors[1]
+                }
+            },
+            title: {
+                text: '월별 경매 수',
+                style: {
+                    color: Highcharts.getOptions().colors[1]
+                }
+            }
+        }, {
+            title: {
+                text: '월별 경쟁률',
+                style: {
+                    color: Highcharts.getOptions().colors[0]
+                }
+            },
+            labels: {
+                format: '{value}',
+                style: {
+                    color: Highcharts.getOptions().colors[0]
+                }
+            },
+            opposite: true
+        }],
+        tooltip: {
+            shared: true
+        },
+        legend: {
+            align: 'left',
+            verticalAlign: 'top',
+            backgroundColor:
+                Highcharts.defaultOptions.legend.backgroundColor ||
+                'rgba(255,255,255,0.25)'
+        },
+        series: [{
+            name: '월별 경매수',
+            type: 'column',
+            yAxis: 1,
+            data: [
+                8, 15, 12, 23, 9, 18, 17, 6, 21,
+                24, 17, 16
+            ],
+            tooltip: {
+                valueSuffix: ' 건'
+            }
 
+        }, {
+            name: '월별 경쟁률',
+            type: 'spline',
+            data: [
+                3.3, 9.5, 14.2, 5.2, 7.0, 12.1, 13.5, 13.6, 8.2,
+                2.8, 12.0, 15.5
+            ],
+        }]
+    });
 }

--- a/pickme/src/main/resources/static/js/statistics/auctionStatistics.js
+++ b/pickme/src/main/resources/static/js/statistics/auctionStatistics.js
@@ -1,0 +1,88 @@
+
+$(document).ready(function() {
+    $.ajax({
+        url: '/api/statistics/auctionStatistics',
+        method: 'GET',
+        dataType: 'json',
+        success: function(response) {
+            if (response.success) {
+                let data = response.data;
+                let totalAuctions = data.totalAuctions;
+                let totalCompetitionRate = data.totalCompetitionRate;
+                let categoryCompetition = data.categoryCompetition;
+                let monthlyBids = data.monthlyBids;
+
+                createTotalAuctionsChart(totalAuctions, totalCompetitionRate);
+            } else {
+                console.error('Failed to fetch data');
+            }
+        },
+        error: function(xhr, status, error) {
+            console.error('Error fetching data:', error);
+        }
+    });
+});
+
+function createTotalAuctionsChart(totalAuctions, totalCompetitionRate){
+    Highcharts.chart('totalAuctionsChart', {
+
+        chart: {
+            type: 'column',
+//            styledMode: true
+        },
+
+        title: {
+            text: '총 경매수/전체 경쟁률',
+            align: 'left'
+        },
+
+        subtitle: {
+            text: 'Source: ' +
+                '<a href="https://www.worlddata.info/average-bodyheight.php"' +
+                'target="_blank">WorldData</a>',
+            align: 'left'
+        },
+
+        xAxis: {
+            categories: ['총 경매수', '전체 경쟁률']
+        },
+
+        yAxis: [{
+            className: 'highcharts-color-0',
+            title: {
+                text: '경매수'
+            },
+            allowDecimals: false
+        }, {
+            className: 'highcharts-color-1',
+            opposite: true,
+            title: {
+                text: '경쟁률'
+            }
+        }],
+
+        plotOptions: {
+            column: {
+                borderRadius: 5
+            }
+        },
+
+        series: [{
+            name: '총 경매수',
+            data: [totalAuctions, 0],
+            yAxis: 0
+    //        tooltip: {
+    //            valueSuffix: ' 건'
+    //        }
+        }, {
+            name: '전체 경쟁률',
+            data: [0, totalCompetitionRate],
+            yAxis: 1
+        }]
+
+    });
+}
+
+function createMonthlyAuctionsChart(monthlyBids){
+
+}

--- a/pickme/src/main/resources/templates/statistics/auctionStatistics.html
+++ b/pickme/src/main/resources/templates/statistics/auctionStatistics.html
@@ -6,7 +6,8 @@
     <title>PICKME</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+KR:wght@100;200;300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+KR:wght@100;200;300;400;500;600;700&display=swap"
+          rel="stylesheet">
     <link rel="stylesheet" th:href="@{/css/statistics/auctionStatistics.css}">
     <link rel="stylesheet" th:href="@{/css/common/header.css}">
     <link rel="stylesheet" th:href="@{/css/common/footer.css}">

--- a/pickme/src/main/resources/templates/statistics/auctionStatistics.html
+++ b/pickme/src/main/resources/templates/statistics/auctionStatistics.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PICKME</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+KR:wght@100;200;300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" th:href="@{/css/statistics/auctionStatistics.css}">
+    <link rel="stylesheet" th:href="@{/css/common/header.css}">
+    <link rel="stylesheet" th:href="@{/css/common/footer.css}">
+
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script src="https://code.highcharts.com/highcharts.js"></script>
+    <script src="https://code.highcharts.com/modules/accessibility.js"></script>
+</head>
+<body>
+<div th:replace="~{fragments/header :: header}">header content</div>
+<div class="container">
+    <div class="notice-content" th:object="${notice}">
+        <div class="dashboard-container">
+            <h1 class=".statistics-title">경매 관련 통계</h1>
+
+            <div class="chart-row">
+                <div class="chart-small">
+                    <h2 class="section-title">총 경매수/전체 경쟁률</h2>
+                    <div class="chart-container">
+                        <div id="totalAuctionsChart"></div>
+                    </div>
+                </div>
+                <div class="chart-middle">
+                    <h2 class="section-title">카테고리별 경쟁률</h2>
+                    <div class="chart-container">
+                        <div id="categoryCompetitionChart"></div>
+                    </div>
+                </div>
+            </div>
+
+            <h2 class="section-title">월별 경매 수/경쟁률</h2>
+            <div class="chart-container chart-large">
+                <div id="monthlyAuctionsChart"></div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script th:src="@{/js/statistics/auctionStatistics.js}"></script>
+</body>
+</html>


### PR DESCRIPTION
## 🍀이슈 번호 (이슈 번호를 작성해주세요)
- closes #172 

## ✅ 구현 내용
- [x] 경매 내용 관련 통계 페이지 구현

## 🐸고민사항 & 기타

- 데이터가 골고루 있지 못하고 유의미한 데이터가 없어 [총 경수/전체 경쟁률]을 제외하고현재 샘플 데이터만 넣어두었습니다.

<img width="1280" alt="image" src="https://github.com/user-attachments/assets/a476616f-f58c-4ea2-98e1-a812967ea0e4">
<img width="1279" alt="image" src="https://github.com/user-attachments/assets/cfa9f639-ccbf-4ca5-85a6-178cc4df533f">

